### PR TITLE
Fix parent county high and first case counts

### DIFF
--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -116,8 +116,8 @@ pub fn merge_csv_gis_cases(
                         .iter()
                         .max_by_key(|x| x.deathsToday)
                         .unwrap();
-                    let first_case = combined_ts_cases.iter().find(|x| x.confirmed > 0).unwrap();
-                    let first_death = combined_ts_cases.iter().find(|x| x.deaths > 0).unwrap();
+                    let first_case = combined_ts_cases.iter().find(|x| x.confirmed > 0);
+                    let first_death = combined_ts_cases.iter().find(|x| x.deaths > 0);
 
                     case_found.confirmed += gis_case.Confirmed;
                     case_found.recovered += gis_case.Recovered;
@@ -129,8 +129,15 @@ pub fn merge_csv_gis_cases(
                     case_found.provincesList.push(province_type);
                     case_found.hasProvince = true;
 
-                    case_found.dateOfFirstCase = Some(first_case.day.clone());
-                    case_found.dateOfFirstDeath = Some(first_death.day.clone());
+                    case_found.dateOfFirstCase = match first_case {
+                        Some(ts_case) => Some(ts_case.day.clone()),
+                        None => None,
+                    };
+
+                    case_found.dateOfFirstDeath = match first_death {
+                        Some(ts_case) => Some(ts_case.day.clone()),
+                        None => None,
+                    };
 
                     case_found.highestDailyConfirmed = HighestCase {
                         count: max_daily_confirmed.confirmedCasesToday,

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -140,11 +140,11 @@ pub fn merge_csv_gis_cases(
                     let case_found_first_death =
                         convert_option_to_date(case_found.dateOfFirstDeath.clone());
 
-                    if csv_case_first_case > case_found_first_case {
+                    if csv_case_first_case < case_found_first_case {
                         case_found.dateOfFirstCase = csv_case.dateOfFirstCase.clone();
                     }
 
-                    if csv_case_first_death > case_found_first_death {
+                    if csv_case_first_death < case_found_first_death {
                         case_found.dateOfFirstDeath = csv_case.dateOfFirstDeath.clone();
                     }
 


### PR DESCRIPTION
Fixes an issue where the highest daily confirmed and death cases of a county that contains provinces/states was incorrectly calculated.
In addition to this, the first cases and deaths of a country with provinces/states would be incorrect before this fix.